### PR TITLE
Remove "break_outer" variable

### DIFF
--- a/timsort.hpp
+++ b/timsort.hpp
@@ -443,7 +443,6 @@ template <typename RandomAccessIterator, typename LessFunction> class TimSort {
             int count1 = 0;
             int count2 = 0;
 
-            bool break_outer = false;
             do {
                 assert(len1 > 1 && len2 > 0);
 
@@ -452,22 +451,17 @@ template <typename RandomAccessIterator, typename LessFunction> class TimSort {
                     ++count2;
                     count1 = 0;
                     if (--len2 == 0) {
-                        break_outer = true;
-                        break;
+                        goto break_outer;
                     }
                 } else {
                     *(dest++) = GFX_TIMSORT_MOVE(*(cursor1++));
                     ++count1;
                     count2 = 0;
                     if (--len1 == 1) {
-                        break_outer = true;
-                        break;
+                        goto break_outer;
                     }
                 }
             } while ((count1 | count2) < minGallop);
-            if (break_outer) {
-                break;
-            }
 
             do {
                 assert(len1 > 1 && len2 > 0);
@@ -480,14 +474,12 @@ template <typename RandomAccessIterator, typename LessFunction> class TimSort {
                     len1 -= count1;
 
                     if (len1 <= 1) {
-                        break_outer = true;
-                        break;
+                        goto break_outer;
                     }
                 }
                 *(dest++) = GFX_TIMSORT_MOVE(*(cursor2++));
                 if (--len2 == 0) {
-                    break_outer = true;
-                    break;
+                    goto break_outer;
                 }
 
                 count2 = gallopLeft(*cursor1, cursor2, len2, 0);
@@ -497,27 +489,23 @@ template <typename RandomAccessIterator, typename LessFunction> class TimSort {
                     cursor2 += count2;
                     len2 -= count2;
                     if (len2 == 0) {
-                        break_outer = true;
-                        break;
+                        goto break_outer;
                     }
                 }
                 *(dest++) = GFX_TIMSORT_MOVE(*(cursor1++));
                 if (--len1 == 1) {
-                    break_outer = true;
-                    break;
+                    goto break_outer;
                 }
 
                 --minGallop;
             } while ((count1 >= MIN_GALLOP) | (count2 >= MIN_GALLOP));
-            if (break_outer) {
-                break;
-            }
 
             if (minGallop < 0) {
                 minGallop = 0;
             }
             minGallop += 2;
         } // end of "outer" loop
+    break_outer:
 
         minGallop_ = std::min(minGallop, 1);
 
@@ -562,7 +550,6 @@ template <typename RandomAccessIterator, typename LessFunction> class TimSort {
             int count1 = 0;
             int count2 = 0;
 
-            bool break_outer = false;
             do {
                 assert(len1 > 0 && len2 > 1);
 
@@ -571,22 +558,17 @@ template <typename RandomAccessIterator, typename LessFunction> class TimSort {
                     ++count1;
                     count2 = 0;
                     if (--len1 == 0) {
-                        break_outer = true;
-                        break;
+                        goto break_outer;
                     }
                 } else {
                     *(dest--) = GFX_TIMSORT_MOVE(*(cursor2--));
                     ++count2;
                     count1 = 0;
                     if (--len2 == 1) {
-                        break_outer = true;
-                        break;
+                        goto break_outer;
                     }
                 }
             } while ((count1 | count2) < minGallop);
-            if (break_outer) {
-                break;
-            }
 
             do {
                 assert(len1 > 0 && len2 > 1);
@@ -599,14 +581,12 @@ template <typename RandomAccessIterator, typename LessFunction> class TimSort {
                     GFX_TIMSORT_MOVE_BACKWARD(cursor1 + 1, cursor1 + (1 + count1), dest + (1 + count1));
 
                     if (len1 == 0) {
-                        break_outer = true;
-                        break;
+                        goto break_outer;
                     }
                 }
                 *(dest--) = GFX_TIMSORT_MOVE(*(cursor2--));
                 if (--len2 == 1) {
-                    break_outer = true;
-                    break;
+                    goto break_outer;
                 }
 
                 count2 = len2 - gallopLeft(*cursor1, tmp_.begin(), len2, len2 - 1);
@@ -616,27 +596,23 @@ template <typename RandomAccessIterator, typename LessFunction> class TimSort {
                     len2 -= count2;
                     GFX_TIMSORT_MOVE_RANGE(cursor2 + 1, cursor2 + (1 + count2), dest + 1);
                     if (len2 <= 1) {
-                        break_outer = true;
-                        break;
+                        goto break_outer;
                     }
                 }
                 *(dest--) = GFX_TIMSORT_MOVE(*(cursor1--));
                 if (--len1 == 0) {
-                    break_outer = true;
-                    break;
+                    goto break_outer;
                 }
 
                 minGallop--;
             } while ((count1 >= MIN_GALLOP) | (count2 >= MIN_GALLOP));
-            if (break_outer) {
-                break;
-            }
 
             if (minGallop < 0) {
                 minGallop = 0;
             }
             minGallop += 2;
         } // end of "outer" loop
+    break_outer:
 
         minGallop_ = std::min(minGallop, 1);
 


### PR DESCRIPTION
Yes, "goto considered harmful" and all that.  However, it really is the most direct way of breaking out of multiple levels of loops.

Using a temporary boolean like this code had been doing actually requires more work at the assembly level.  An `if` statement that just has a `break` or `goto` as its contents will likely compile down to a single branch instruction.  However, if you have to do anything else in the body, you now have a code block that needs to be branched around in the false case.  So in pseudo-assembly instead of:
```
  beq FOO
```
you could have:
```
  bne FALSE
  mov %r1, TRUE
  jmp FOO
FALSE:
```
It's possible that the compiler's flowgraph optimizer will manage to pull out the temporary variable and do this transformation itself... but it's really asking a lot.  I don't think it's any less readable to just change to a `goto` and express directly where we want controlflow to go