### PR TITLE
Use existing Catch2 v2.x git branch instead of deleted master

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ include(DownloadProject)
 # Download and configure Catch2 for the tests
 download_project(PROJ Catch2
                  GIT_REPOSITORY https://github.com/catchorg/Catch2
-                 GIT_TAG master
+                 GIT_TAG v2.x
                  UPDATE_DISCONNECTED 1
 )
 add_subdirectory(${Catch2_SOURCE_DIR} ${Catch2_BINARY_DIR})


### PR DESCRIPTION
Tests do not compile against the default Catch2 branch devel (where the
next major version, v3, of Catch2 is being developed).