### PR TITLE
Make TimSort::gallop* static

### DIFF
--- a/include/gfx/timsort.hpp
+++ b/include/gfx/timsort.hpp
@@ -264,7 +264,8 @@ template <typename RandomAccessIterator, typename Compare> class TimSort {
     }
 
     template <typename Iter>
-    diff_t gallopLeft(ref_t key, Iter const base, diff_t const len, diff_t const hint, Compare compare) {
+    static diff_t gallopLeft(ref_t key, Iter const base, diff_t const len,
+                             diff_t const hint, Compare compare) {
         GFX_TIMSORT_ASSERT(len > 0);
         GFX_TIMSORT_ASSERT(hint >= 0);
         GFX_TIMSORT_ASSERT(hint < len);
@@ -314,7 +315,8 @@ template <typename RandomAccessIterator, typename Compare> class TimSort {
     }
 
     template <typename Iter>
-    diff_t gallopRight(ref_t key, Iter const base, diff_t const len, diff_t const hint, Compare compare) {
+    static diff_t gallopRight(ref_t key, Iter const base, diff_t const len,
+                              diff_t const hint, Compare compare) {
         GFX_TIMSORT_ASSERT(len > 0);
         GFX_TIMSORT_ASSERT(hint >= 0);
         GFX_TIMSORT_ASSERT(hint < len);


### PR DESCRIPTION
These member functions do not use data members and don't need a pointer to a `TimSort` object.